### PR TITLE
Add tags for `think-bayes-scala` and add `sbt-classfinder` SBT plugin

### DIFF
--- a/keywords.json
+++ b/keywords.json
@@ -2047,7 +2047,7 @@
   "rubanm/ignite-scala": [],
   "ruippeixotog/classutil": [],
   "ruippeixotog/scala-scraper": ["html", "scraping"],
-  "ruippeixotog/think-bayes-scala": [],
+  "ruippeixotog/think-bayes-scala": ["math", "ml"],
   "runarorama/scala-bound": [],
   "runarorama/scala-machines": ["fp"],
   "ryanbrozo/spray-hawk": [],


### PR DESCRIPTION
This pull request adds tags for `think-bayes-scala`. It also replaces `ruippeixotog/classutil`, which is now only a simple fork of `bmc/classutil`, by `ruippeixotog/sbt-classfinder`, a related SBT plugin.
